### PR TITLE
feat: add filter to management command

### DIFF
--- a/openedx_search/settings/test.py
+++ b/openedx_search/settings/test.py
@@ -36,22 +36,6 @@ INDEX_CONFIGURATIONS = {
         },
         "model_class": "auth.User",
         "fields": "__all__"
-    },
-    "courseware_course_structure": {
-        "options": {
-            "primaryKey": "item_id"
-        },
-        "settings": {
-            "filterableAttributes": [
-                "CONTENT_TYPE",
-                "COURSE",
-                "ORG"
-            ]
-        },
-        "search_rules": [
-            "ORG: Arbisoft"
-        ],
-        "content_class": "openedx.core.djangoapps.content.content_classes.courseware_search_models.CoursewareContent"
     }
 }
 MEILISEARCH_API_KEY_ID = "c471bd40-303b-48bc-bb80-4602baff2675"

--- a/openedx_search_api/drivers/meilisearch.py
+++ b/openedx_search_api/drivers/meilisearch.py
@@ -65,7 +65,7 @@ class MeiliSearchEngine(BaseDriver):  # pylint disable=too-many-instance-attribu
             meilisearch_public_url,
             meilisearch_master_api_key,
             expiry_days=7
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self._index = None
         self.url = meilisearch_url
         self.public_url = meilisearch_public_url

--- a/openedx_search_api/tests/base_tests.py
+++ b/openedx_search_api/tests/base_tests.py
@@ -2,8 +2,10 @@
 Unit tests for the MeiliSearchEngine driver in the openedx_search_api package.
 """
 import json
+from io import StringIO
 
 from django.contrib.auth import get_user_model
+from django.core import management
 from django.test import TestCase, RequestFactory
 
 from openedx_search_api.drivers import DriverFactory
@@ -55,3 +57,18 @@ class DriverTestCase(TestCase):
         self.assertIn('token', payload)
         self.assertIn('expires_at', payload)
         self.assertIn('search_engine', payload)
+
+
+class CommandTest(TestCase):
+    """
+    This test case if covering management commands
+    """
+
+    def test_load_indexes(self):
+        """
+        This test is calling load_indexes management command
+        :return:
+        """
+        out = StringIO()
+        management.call_command('load_indexes', verbosity=1, stdout=out)
+        self.assertEqual(out.getvalue(), '')


### PR DESCRIPTION
Added functionality to allow user to update specific index. It also allow to put basic filters in management command.

- [x] Update data for specific index e.g. `./manage.py lms load_indexes -i user_content`
- [x] Allow  filters in management command e.g. `./manage.py lms load_indexes -i user_content --filters="username=qasim"`